### PR TITLE
Upgrade alpine and yamllint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ env:
     - VERSION=1.23
     - VERSION=1.24
     - VERSION=1.25
+    - VERSION=1.26
     - VERSION=latest
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM alpine:3.11 as builder
+FROM alpine:3.13.2 as base
+
+FROM base as builder
 
 RUN set -eux \
 	&& apk add --no-cache \
 		bc \
-		python3
+		python3 \
+                cmd:pip3
 
 ARG VERSION
 RUN set -eux \
@@ -19,7 +22,7 @@ RUN set -eux \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
 
-FROM alpine:3.11 as production
+FROM base as production
 ARG VERSION
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 #LABEL "org.opencontainers.image.created"=""


### PR DESCRIPTION
Thanks for creating and maintaining this docker image!
We're about to integrate it as default validator into our [GitOps library](https://github.com/cloudogu/gitops-build-lib/blob/0c4abf83b1fc8aa3542055abd59cac81d8b7b9e1/vars/deployViaGitops.groovy#L34).

An image scan using trivy revealed that it would be a good idea to upgrade the base image in advance.
Also, a new yamllint version is available.

* Add latest yamllint 1.16
* Upgrade to alpine 3.13

If you care to find out about the details of the trivy scan:

```shell
docker run --rm -v trivy-cache:/root/.cache \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v/tmp:/tmp \
  aquasec/trivy:0.16.0 image \
  cytopia/yamllint@sha256:610c78c5e0d2d05c220b55293dfb34003949abe85bfde6e8397f57af6faad231
# Repo digest corresponding to cytopia/yamllint:1.25-0.7 at the moment
```